### PR TITLE
Correct App name in French

### DIFF
--- a/fastlane/metadata/android/fr-FR/title.txt
+++ b/fastlane/metadata/android/fr-FR/title.txt
@@ -1,1 +1,1 @@
-Simple Lancez
+Lanceur simple


### PR DESCRIPTION
Same name as in `app/src/main/res/values-fr/strings.xml`.