### PR TITLE
Support for custom columns and rows in app drawer

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
@@ -152,8 +152,8 @@ class MainActivity : SimpleActivity(), FlingListener {
             }
         }
 
-        for (checkedYCell in 0 until COLUMN_COUNT) {
-            for (checkedXCell in 0 until ROW_COUNT - 1) {
+        for (checkedYCell in 0 until DEFAULT_COLUMN_COUNT) {
+            for (checkedXCell in 0 until DEFAULT_ROW_COUNT - 1) {
                 val wantedCell = Pair(checkedXCell, checkedYCell)
                 if (!occupiedCells.contains(wantedCell)) {
                     return Rect(wantedCell.first, wantedCell.second, wantedCell.first, wantedCell.second)
@@ -237,6 +237,7 @@ class MainActivity : SimpleActivity(), FlingListener {
                     refetchLaunchers()
                 }
             }
+
             REQUEST_ALLOW_BINDING_WIDGET -> mActionOnCanBindWidget?.invoke(resultCode == Activity.RESULT_OK)
             REQUEST_CONFIGURE_WIDGET -> mActionOnWidgetConfiguredWidget?.invoke(resultCode == Activity.RESULT_OK)
             REQUEST_CREATE_SHORTCUT -> {
@@ -245,6 +246,12 @@ class MainActivity : SimpleActivity(), FlingListener {
                     val label = resultData.getStringExtra(Intent.EXTRA_SHORTCUT_NAME) ?: ""
                     val icon = resultData.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON) as? Bitmap
                     mActionOnAddShortcut?.invoke(label, icon, launchIntent?.toUri(0).toString())
+                }
+            }
+
+            REQUEST_ROW_COLUMN_CHANGE -> {
+                if (resultCode == Activity.RESULT_OK) {
+                    (all_apps_fragment as? AllAppsFragment)?.updateRowAndColumnCount()
                 }
             }
         }
@@ -469,7 +476,7 @@ class MainActivity : SimpleActivity(), FlingListener {
         mLongPressedIcon = gridItem
         val anchorY = if (isOnAllAppsFragment || gridItem.type == ITEM_TYPE_WIDGET) {
             y
-        } else if (gridItem.top == ROW_COUNT - 1) {
+        } else if (gridItem.top == DEFAULT_ROW_COUNT - 1) {
             home_screen_grid.sideMargins.top + (gridItem.top * home_screen_grid.cellHeight.toFloat())
         } else {
             (gridItem.top * home_screen_grid.cellHeight.toFloat())
@@ -699,7 +706,22 @@ class MainActivity : SimpleActivity(), FlingListener {
             val defaultDialerPackage = (getSystemService(Context.TELECOM_SERVICE) as TelecomManager).defaultDialerPackage
             appLaunchers.firstOrNull { it.packageName == defaultDialerPackage }?.apply {
                 val dialerIcon =
-                    HomeScreenGridItem(null, 0, ROW_COUNT - 1, 0, ROW_COUNT - 1, defaultDialerPackage, "", title, ITEM_TYPE_ICON, "", -1, "", "", null)
+                    HomeScreenGridItem(
+                        null,
+                        0,
+                        DEFAULT_ROW_COUNT - 1,
+                        0,
+                        DEFAULT_ROW_COUNT - 1,
+                        defaultDialerPackage,
+                        "",
+                        title,
+                        ITEM_TYPE_ICON,
+                        "",
+                        -1,
+                        "",
+                        "",
+                        null
+                    )
                 homeScreenGridItems.add(dialerIcon)
             }
         } catch (e: Exception) {
@@ -709,7 +731,22 @@ class MainActivity : SimpleActivity(), FlingListener {
             val defaultSMSMessengerPackage = Telephony.Sms.getDefaultSmsPackage(this)
             appLaunchers.firstOrNull { it.packageName == defaultSMSMessengerPackage }?.apply {
                 val SMSMessengerIcon =
-                    HomeScreenGridItem(null, 1, ROW_COUNT - 1, 1, ROW_COUNT - 1, defaultSMSMessengerPackage, "", title, ITEM_TYPE_ICON, "", -1, "", "", null)
+                    HomeScreenGridItem(
+                        null,
+                        1,
+                        DEFAULT_ROW_COUNT - 1,
+                        1,
+                        DEFAULT_ROW_COUNT - 1,
+                        defaultSMSMessengerPackage,
+                        "",
+                        title,
+                        ITEM_TYPE_ICON,
+                        "",
+                        -1,
+                        "",
+                        "",
+                        null
+                    )
                 homeScreenGridItems.add(SMSMessengerIcon)
             }
         } catch (e: Exception) {
@@ -721,7 +758,22 @@ class MainActivity : SimpleActivity(), FlingListener {
             val defaultBrowserPackage = resolveInfo!!.activityInfo.packageName
             appLaunchers.firstOrNull { it.packageName == defaultBrowserPackage }?.apply {
                 val browserIcon =
-                    HomeScreenGridItem(null, 2, ROW_COUNT - 1, 2, ROW_COUNT - 1, defaultBrowserPackage, "", title, ITEM_TYPE_ICON, "", -1, "", "", null)
+                    HomeScreenGridItem(
+                        null,
+                        2,
+                        DEFAULT_ROW_COUNT - 1,
+                        2,
+                        DEFAULT_ROW_COUNT - 1,
+                        defaultBrowserPackage,
+                        "",
+                        title,
+                        ITEM_TYPE_ICON,
+                        "",
+                        -1,
+                        "",
+                        "",
+                        null
+                    )
                 homeScreenGridItems.add(browserIcon)
             }
         } catch (e: Exception) {
@@ -732,7 +784,22 @@ class MainActivity : SimpleActivity(), FlingListener {
             val storePackage = potentialStores.firstOrNull { isPackageInstalled(it) && appLaunchers.map { it.packageName }.contains(it) }
             if (storePackage != null) {
                 appLaunchers.firstOrNull { it.packageName == storePackage }?.apply {
-                    val storeIcon = HomeScreenGridItem(null, 3, ROW_COUNT - 1, 3, ROW_COUNT - 1, storePackage, "", title, ITEM_TYPE_ICON, "", -1, "", "", null)
+                    val storeIcon = HomeScreenGridItem(
+                        null,
+                        3,
+                        DEFAULT_ROW_COUNT - 1,
+                        3,
+                        DEFAULT_ROW_COUNT - 1,
+                        storePackage,
+                        "",
+                        title,
+                        ITEM_TYPE_ICON,
+                        "",
+                        -1,
+                        "",
+                        "",
+                        null
+                    )
                     homeScreenGridItems.add(storeIcon)
                 }
             }
@@ -745,7 +812,22 @@ class MainActivity : SimpleActivity(), FlingListener {
             val defaultCameraPackage = resolveInfo!!.activityInfo.packageName
             appLaunchers.firstOrNull { it.packageName == defaultCameraPackage }?.apply {
                 val cameraIcon =
-                    HomeScreenGridItem(null, 4, ROW_COUNT - 1, 4, ROW_COUNT - 1, defaultCameraPackage, "", title, ITEM_TYPE_ICON, "", -1, "", "", null)
+                    HomeScreenGridItem(
+                        null,
+                        4,
+                        DEFAULT_ROW_COUNT - 1,
+                        4,
+                        DEFAULT_ROW_COUNT - 1,
+                        defaultCameraPackage,
+                        "",
+                        title,
+                        ITEM_TYPE_ICON,
+                        "",
+                        -1,
+                        "",
+                        "",
+                        null
+                    )
                 homeScreenGridItems.add(cameraIcon)
             }
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.launcher.activities
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import com.simplemobiletools.commons.extensions.*
@@ -8,6 +9,7 @@ import com.simplemobiletools.commons.helpers.isTiramisuPlus
 import com.simplemobiletools.commons.models.FAQItem
 import com.simplemobiletools.launcher.BuildConfig
 import com.simplemobiletools.launcher.R
+import com.simplemobiletools.launcher.dialogs.RowColumnPickerDialog
 import com.simplemobiletools.launcher.extensions.config
 import kotlinx.android.synthetic.main.activity_settings.*
 import java.util.*
@@ -34,11 +36,26 @@ class SettingsActivity : SimpleActivity() {
         setupUseEnglish()
         setupLanguage()
         setupManageHiddenIcons()
+        setupAppGridSize()
         updateTextColors(settings_holder)
 
         arrayOf(settings_color_customization_section_label, settings_general_settings_label).forEach {
             it.setTextColor(getProperPrimaryColor())
         }
+    }
+
+    private fun setupAppGridSize() {
+        updateGridText()
+        settings_drawer_app_grid.setOnClickListener {
+            RowColumnPickerDialog(this) {
+                updateGridText()
+                setResult(Activity.RESULT_OK)
+            }
+        }
+    }
+
+    private fun updateGridText() {
+        settings_grid_text.text = getString(R.string.grid_text, config.rowCount, config.columnCount)
     }
 
     private fun setupOptionsMenu() {

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/adapters/LaunchersAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/adapters/LaunchersAdapter.kt
@@ -1,8 +1,10 @@
 package com.simplemobiletools.launcher.adapters
 
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -11,14 +13,15 @@ import com.bumptech.glide.request.transition.DrawableCrossFadeFactory
 import com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller
 import com.simplemobiletools.commons.extensions.getColoredDrawableWithColor
 import com.simplemobiletools.commons.extensions.getProperTextColor
-import com.simplemobiletools.commons.extensions.portrait
 import com.simplemobiletools.commons.extensions.realScreenSize
 import com.simplemobiletools.launcher.R
 import com.simplemobiletools.launcher.activities.SimpleActivity
+import com.simplemobiletools.launcher.extensions.config
 import com.simplemobiletools.launcher.interfaces.AllAppsListener
 import com.simplemobiletools.launcher.models.AppLauncher
 import com.simplemobiletools.launcher.models.HomeScreenGridItem
-import kotlinx.android.synthetic.main.item_launcher_label.view.*
+import kotlinx.android.synthetic.main.item_launcher_label.view.launcher_icon
+import kotlinx.android.synthetic.main.item_launcher_label.view.launcher_label
 
 class LaunchersAdapter(
     val activity: SimpleActivity,
@@ -37,6 +40,7 @@ class LaunchersAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_launcher_label, parent, false)
+        setSizeOfViewHolder(view)
         return ViewHolder(view)
     }
 
@@ -47,16 +51,24 @@ class LaunchersAdapter(
     override fun getItemCount() = launchers.size
 
     private fun calculateIconWidth() {
-        val currentColumnCount = activity.resources.getInteger(
-            if (activity.portrait) {
-                R.integer.portrait_column_count
-            } else {
-                R.integer.landscape_column_count
-            }
-        )
-
-        val iconWidth = activity.realScreenSize.x / currentColumnCount
+        val iconWidth = activity.realScreenSize.x / activity.config.columnCount
         iconPadding = (iconWidth * 0.1f).toInt()
+    }
+
+    private fun setSizeOfViewHolder(view: View) {
+        val displayMetrics = view.context.resources.displayMetrics
+        val rowCount = view.context.config.rowCount
+        val columnCount = view.context.config.columnCount
+        val screenHeight = displayMetrics.heightPixels / displayMetrics.density
+        val screenWidth = displayMetrics.widthPixels / displayMetrics.density
+        val columnWidth = screenWidth / columnCount
+        val rowHeight = screenHeight / rowCount
+        val rowHeightPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, rowHeight, displayMetrics).toInt()
+        val columnWidthPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, columnWidth, displayMetrics).toInt()
+        view.updateLayoutParams<ViewGroup.LayoutParams> {
+            height = rowHeightPx
+            width = columnWidthPx
+        }
     }
 
     fun hideIcon(item: HomeScreenGridItem) {

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/dialogs/RowColumnPickerDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/dialogs/RowColumnPickerDialog.kt
@@ -1,0 +1,52 @@
+package com.simplemobiletools.launcher.dialogs
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.view.ViewGroup
+import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.launcher.R
+import com.simplemobiletools.launcher.extensions.config
+import com.simplemobiletools.launcher.helpers.MAX_COLUMN_COUNT
+import com.simplemobiletools.launcher.helpers.MAX_ROW_COUNT
+import com.simplemobiletools.launcher.helpers.MIN_COLUMN_COUNT
+import com.simplemobiletools.launcher.helpers.MIN_ROW_COUNT
+import kotlinx.android.synthetic.main.dialog_row_column.view.column_number_picker
+import kotlinx.android.synthetic.main.dialog_row_column.view.row_number_picker
+
+class RowColumnPickerDialog(private val activity: Activity, private val callback: () -> Unit) {
+
+    init {
+        val view = (activity.layoutInflater.inflate(R.layout.dialog_row_column, null) as ViewGroup)
+        view.apply {
+            row_number_picker?.apply {
+                maxValue = MAX_ROW_COUNT
+                minValue = MIN_ROW_COUNT
+                wrapSelectorWheel = false
+                value = activity.config.rowCount
+            }
+
+            column_number_picker?.apply {
+                maxValue = MAX_COLUMN_COUNT
+                minValue = MIN_COLUMN_COUNT
+                wrapSelectorWheel = false
+                value = activity.config.columnCount
+            }
+        }
+        activity.getAlertDialogBuilder()
+            .setPositiveButton(R.string.save, null)
+            .apply {
+                activity.setupDialogStuff(view, this, titleText = activity.getString(R.string.set_drawer_grid_text)) { alertDialog ->
+                    alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                        val rows = view.row_number_picker.value
+                        val column = view.column_number_picker.value
+
+                        activity.config.rowCount = rows
+                        activity.config.columnCount = column
+                        callback()
+                        alertDialog.dismiss()
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/extensions/Activity.kt
@@ -7,13 +7,14 @@ import android.net.Uri
 import android.provider.Settings
 import com.simplemobiletools.commons.extensions.showErrorToast
 import com.simplemobiletools.launcher.activities.SettingsActivity
+import com.simplemobiletools.launcher.helpers.REQUEST_ROW_COLUMN_CHANGE
 import com.simplemobiletools.launcher.helpers.UNINSTALL_APP_REQUEST_CODE
 import com.simplemobiletools.launcher.models.HomeScreenGridItem
 
 fun Activity.launchApp(packageName: String, activityName: String) {
     // if this is true, launch the app settings
     if (packageName == this.packageName) {
-        startActivity(Intent(applicationContext, SettingsActivity::class.java))
+        startActivityForResult(Intent(applicationContext, SettingsActivity::class.java), REQUEST_ROW_COLUMN_CHANGE)
         return
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/AllAppsFragment.kt
@@ -13,7 +13,7 @@ import com.simplemobiletools.commons.views.MyGridLayoutManager
 import com.simplemobiletools.launcher.R
 import com.simplemobiletools.launcher.activities.MainActivity
 import com.simplemobiletools.launcher.adapters.LaunchersAdapter
-import com.simplemobiletools.launcher.extensions.getColumnCount
+import com.simplemobiletools.launcher.extensions.config
 import com.simplemobiletools.launcher.extensions.launchApp
 import com.simplemobiletools.launcher.helpers.ITEM_TYPE_ICON
 import com.simplemobiletools.launcher.interfaces.AllAppsListener
@@ -50,9 +50,17 @@ class AllAppsFragment(context: Context, attributeSet: AttributeSet) : MyFragment
         setupViews()
 
         val layoutManager = all_apps_grid.layoutManager as MyGridLayoutManager
-        layoutManager.spanCount = context.getColumnCount()
+        layoutManager.spanCount = context.config.columnCount
         val launchers = (all_apps_grid.adapter as LaunchersAdapter).launchers
         setupAdapter(launchers)
+    }
+
+    fun updateRowAndColumnCount() {
+        // invalidate the adapter
+        val launchers = (all_apps_grid.adapter as LaunchersAdapter).launchers
+        setupAdapter(launchers, true)
+        all_apps_grid.invalidate()
+        all_apps_grid.requestLayout()
     }
 
     override fun onInterceptTouchEvent(event: MotionEvent?): Boolean {
@@ -97,13 +105,13 @@ class AllAppsFragment(context: Context, attributeSet: AttributeSet) : MyFragment
         setupAdapter(sorted)
     }
 
-    private fun setupAdapter(launchers: ArrayList<AppLauncher>) {
+    private fun setupAdapter(launchers: ArrayList<AppLauncher>, overrideAdapter: Boolean = false) {
         activity?.runOnUiThread {
             val layoutManager = all_apps_grid.layoutManager as MyGridLayoutManager
-            layoutManager.spanCount = context.getColumnCount()
+            layoutManager.spanCount = context.config.columnCount
 
             val currAdapter = all_apps_grid.adapter
-            if (currAdapter == null) {
+            if (currAdapter == null || overrideAdapter.not()) {
                 LaunchersAdapter(activity!!, launchers, this) {
                     activity?.launchApp((it as AppLauncher).packageName, it.activityName)
                     ignoreTouches = false

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Config.kt
@@ -6,9 +6,21 @@ import com.simplemobiletools.commons.helpers.BaseConfig
 class Config(context: Context) : BaseConfig(context) {
     companion object {
         fun newInstance(context: Context) = Config(context)
+
+        // Config keys
+        private const val ROW_COUNT = "row_count"
+        private const val COLUMN_COUNT = "column_count"
     }
 
     var wasHomeScreenInit: Boolean
         get() = prefs.getBoolean(WAS_HOME_SCREEN_INIT, false)
         set(wasHomeScreenInit) = prefs.edit().putBoolean(WAS_HOME_SCREEN_INIT, wasHomeScreenInit).apply()
+
+    var rowCount: Int
+        get() = prefs.getInt(ROW_COUNT, DEFAULT_ROW_COUNT)
+        set(rows) = prefs.edit().putInt(ROW_COUNT, rows).apply()
+
+    var columnCount: Int
+        get() = prefs.getInt(COLUMN_COUNT, DEFAULT_COLUMN_COUNT)
+        set(rows) = prefs.edit().putInt(COLUMN_COUNT, rows).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Constants.kt
@@ -11,8 +11,8 @@ const val ROW_COUNT = 6
 const val COLUMN_COUNT = 5
 
 // default app drawer grid size
-const val DEFAULT_ROW_COUNT = 3
-const val DEFAULT_COLUMN_COUNT = 3
+const val DEFAULT_ROW_COUNT = 6
+const val DEFAULT_COLUMN_COUNT = 5
 const val MAX_ROW_COUNT = 6
 const val MAX_COLUMN_COUNT = 5
 const val MIN_ROW_COUNT = 3

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/helpers/Constants.kt
@@ -10,10 +10,19 @@ const val WAS_HOME_SCREEN_INIT = "was_home_screen_init"
 const val ROW_COUNT = 6
 const val COLUMN_COUNT = 5
 
+// default app drawer grid size
+const val DEFAULT_ROW_COUNT = 3
+const val DEFAULT_COLUMN_COUNT = 3
+const val MAX_ROW_COUNT = 6
+const val MAX_COLUMN_COUNT = 5
+const val MIN_ROW_COUNT = 3
+const val MIN_COLUMN_COUNT = 3
+
 const val UNINSTALL_APP_REQUEST_CODE = 50
 const val REQUEST_CONFIGURE_WIDGET = 51
 const val REQUEST_ALLOW_BINDING_WIDGET = 52
 const val REQUEST_CREATE_SHORTCUT = 53
+const val REQUEST_ROW_COLUMN_CHANGE = 54
 
 const val ITEM_TYPE_ICON = 0
 const val ITEM_TYPE_WIDGET = 1

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -135,6 +135,28 @@
                     android:text="@string/manage_hidden_icons" />
 
             </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/settings_drawer_app_grid"
+                style="@style/SettingsHolderTextViewOneLinerStyle"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/ripple_bottom_corners">
+
+                <com.simplemobiletools.commons.views.MyTextView
+                    android:id="@+id/settings_drawer_app_grid_text"
+                    style="@style/SettingsTextLabelStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Drawer App Grid" />
+                <com.simplemobiletools.commons.views.MyTextView
+                    android:id="@+id/settings_grid_text"
+                    style="@style/SettingsTextValueStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/settings_drawer_app_grid_text"
+                    tools:text="2 X 5" />
+            </RelativeLayout>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_row_column.xml
+++ b/app/src/main/res/layout/dialog_row_column.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/normal_margin"
+        android:layout_marginTop="@dimen/section_margin"
+        android:gravity="center"
+        android:text="@string/rows"
+        app:layout_constraintBottom_toTopOf="@+id/row_number_picker"
+        app:layout_constraintEnd_toEndOf="@+id/row_number_picker"
+        app:layout_constraintStart_toStartOf="@+id/row_number_picker"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <NumberPicker
+        android:id="@+id/row_number_picker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/column_number_picker"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/normal_margin"
+        android:gravity="center"
+        android:layout_marginTop="@dimen/section_margin"
+        android:text="@string/columns"
+        app:layout_constraintBottom_toTopOf="@+id/column_number_picker"
+        app:layout_constraintEnd_toEndOf="@+id/column_number_picker"
+        app:layout_constraintStart_toStartOf="@+id/column_number_picker"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <NumberPicker
+        android:id="@+id/column_number_picker"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/row_number_picker"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_launcher_label.xml
+++ b/app/src/main/res/layout/item_launcher_label.xml
@@ -1,30 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/launcher_holder"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center_horizontal"
     android:background="?attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
-    android:paddingStart="@dimen/small_margin"
-    android:paddingTop="@dimen/medium_margin"
-    android:paddingEnd="@dimen/small_margin"
     android:paddingBottom="@dimen/small_margin">
 
     <com.simplemobiletools.commons.views.MySquareImageView
         android:id="@+id/launcher_icon"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/launcher_icon_size"
-        android:layout_gravity="center_horizontal|bottom" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|bottom"
+        android:foregroundGravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.3" />
 
     <TextView
         android:id="@+id/launcher_label"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_below="@+id/launcher_icon"
+        android:layout_marginTop="@dimen/medium_margin"
         android:ellipsize="end"
-        android:gravity="center_horizontal|top"
+        android:gravity="center"
         android:maxLines="2"
-        android:textSize="@dimen/smaller_text_size" />
+        android:textSize="@dimen/smaller_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/launcher_icon"
+        app:layout_constraintStart_toStartOf="@+id/launcher_icon"
+        app:layout_constraintTop_toBottomOf="@+id/launcher_icon"
+        app:layout_constraintVertical_bias="0.0"
+        tools:text="An App" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">إدارة اﻷيقونات المخفية</string>
     <string name="hidden_icons">اﻷيقونات المخفية</string>
     <string name="hidden_icons_placeholder">لا يمكن إلغاء تثبيت بعض التطبيقات بسبب قيود النظام، ولكن يمكن إخفاء أيقوناتها لتجنب ظهورها.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Gestiona les icones ocultes</string>
     <string name="hidden_icons">Icones ocultes</string>
     <string name="hidden_icons_placeholder">Algunes aplicacions no es poden desinstal·lar a causa de les restriccions del sistema, però almenys podeu ocultar les seves icones per evitar que es vegin.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Spravovat skryté ikony</string>
     <string name="hidden_icons">Skryté ikony</string>
     <string name="hidden_icons_placeholder">Některé aplikace nelze kvůli systémovým omezením odinstalovat. Ale můžete alespoň skrýt jejich ikony, abyste je neviděli.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Ausgeblendete Symbole verwalten</string>
     <string name="hidden_icons">Ausgeblendete Symbole</string>
     <string name="hidden_icons_placeholder">Einige Apps können aufgrund von Systemeinschränkungen nicht deinstalliert werden, aber du kannst zumindest ihre Symbole ausblenden, um sie nicht zu sehen.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">Διαχείριση κρυφών εικονιδίων</string>
     <string name="hidden_icons">Κρυφά εικονίδια</string>
     <string name="hidden_icons_placeholder">Ορισμένες εφαρμογές δεν μπορούν να απεγκατασταθούν λόγω περιορισμών του συστήματος, αλλά μπορείτε να αποκρύψετε τα εικονίδια τους για να μην τις βλέπετε.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Gestionar los iconos ocultos</string>
     <string name="hidden_icons">Iconos ocultos</string>
     <string name="hidden_icons_placeholder">Algunas aplicaciones no se pueden desinstalar debido a las restricciones del sistema, pero al menos puedes ocultar sus iconos para evitar verlas.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Halda peidetud ikoone</string>
     <string name="hidden_icons">Peidetud ikoonid</string>
     <string name="hidden_icons_placeholder">Mõnda rakendust ei saa süsteemipiirangute tõttu eemaldada. Selleks, et neid mitte näha, võid vähemalt nende ikoonid ära peita.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Hallitse piilotettuja kuvakkeita</string>
     <string name="hidden_icons">Piilotetut kuvakkeet</string>
     <string name="hidden_icons_placeholder">Joitakin sovelluksia ei ole järjestelmärajoitusten vuoksi mahdollista poistaa, mutta voit kuitenkin piilottaa niiden kuvakkeet näkyvistä.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Gérer les icônes cachées</string>
     <string name="hidden_icons">Icônes cachées</string>
     <string name="hidden_icons_placeholder">Certaines applications ne peuvent pas être désinstallées en raison de restrictions du système, mais vous pouvez au moins masquer leurs icônes pour éviter de les voir.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Xestionar iconas ocultas</string>
     <string name="hidden_icons">Iconas ocultas</string>
     <string name="hidden_icons_placeholder">Algunhas aplicacións non se poden desinstalar debido ás restricións do sistema, pero polo menos podes ocultar as súas iconas para evitar velas.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Upravljanje skrivenim ikonama</string>
     <string name="hidden_icons">Skrivene ikone</string>
     <string name="hidden_icons_placeholder">Neke aplikacije se ne mogu deinstalirati zbog ograničenja sustava, ali njihove ikone možeš sakriti.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Rejtett ikonok kezelése</string>
     <string name="hidden_icons">Rejtett ikonok</string>
     <string name="hidden_icons_placeholder">Egyes alkalmazások rendszerkorlátozások miatt nem távolíthatók el, de legalább elrejtheti az ikonjaikat, hogy ne lássa őket.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Kelola ikon tersembunyi</string>
     <string name="hidden_icons">Ikon tersembunyi</string>
     <string name="hidden_icons_placeholder">Beberapa aplikasi tidak dapat di-uninstal karena keterbatasan sistem, tetapi Anda masih dapat menyembunyikan ikon mereka untuk menyembunyikannya.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Gestisci le icone nascoste</string>
     <string name="hidden_icons">Icone nascoste</string>
     <string name="hidden_icons_placeholder">Alcune applicazioni non possono essere disinstallate a causa di restrizioni di sistema, ma è possibile almeno nascondere le loro icone per evitare di vederle.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">ניהול אייקונים נסתרים</string>
     <string name="hidden_icons">אייקונים נסתרים</string>
     <string name="hidden_icons_placeholder">חלק מהאפליקציות לא ניתנות להסרה עקב הגבלות מערכת, לפחות אתה יכול להחביא את האייקונים כדי לא לראותם במסך הבית.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">非表示アイコンの管理</string>
     <string name="hidden_icons">非表示のアイコン</string>
     <string name="hidden_icons_placeholder">一部のアプリはシステムの制限によりアンインストールできませんが、非表示によって表示されないようにすることはできます。</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">Manage hidden icons</string>
     <string name="hidden_icons">Hidden icons</string>
     <string name="hidden_icons_placeholder">Some apps cannot be uninstalled due to system restrictions, but you can at least hide their icons to avoid seeing them.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">മറഞ്ഞിരിക്കുന്ന ബിംബം കൈകാര്യം ചെയ്യുക</string>
     <string name="hidden_icons">മറഞ്ഞിരിക്കുന്ന ബിംബ</string>
     <string name="hidden_icons_placeholder">സിസ്റ്റം നിയന്ത്രണങ്ങൾ കാരണം ചില ആപ്പുകൾ അൺഇൻസ്‌റ്റാൾ ചെയ്യാൻ കഴിയില്ല, എന്നാൽ അവ കാണാതിരിക്കാൻ നിങ്ങൾക്ക് അവയുടെ ഐക്കണുകളെങ്കിലും മറയ്‌ക്കാം.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Håndter skjulte ikoner</string>
     <string name="hidden_icons">Skjulte ikoner</string>
     <string name="hidden_icons_placeholder">Noen apper kan ikke avinstalleres pga. systemrestriksjoner, men du kan i det minste skjule deres ikoner for å unngå å se dem.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Verborgen iconen beheren</string>
     <string name="hidden_icons">Verborgen iconen</string>
     <string name="hidden_icons_placeholder">Sommige apps kunnen niet worden verwijderd van het systeem, maar hun iconen kunnen wel worden verborgen.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">لُکاۓ آئیکون دیاں سیٹنگاں</string>
     <string name="hidden_icons">لُکاۓ آئیکون</string>
     <string name="hidden_icons_placeholder">سِسٹم پابندیاں کرکے کجھ اَیپاں اݨ‌اینسٹال کر نہیں سکیاں، پر تسیں آئیکون لُکا سکدے او۔</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Zarządzaj ukrytymi ikonami</string>
     <string name="hidden_icons">Ukryte ikony</string>
     <string name="hidden_icons_placeholder">Niektórych aplikacji nie można odinstalować ze względu na ograniczenia systemowe, ale możesz przynajmniej ukryć ich ikony, aby ich nie widzieć.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">Gerenciar ícones ocultos</string>
     <string name="hidden_icons">Ícones ocultos</string>
     <string name="hidden_icons_placeholder">Alguns aplicativos não podem ser desinstalados devido a restrições do sistema, mas você pode ao menos ocultar seus ícones para evitar vê-los.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">Gerir ícones ocultos</string>
     <string name="hidden_icons">Ícones ocultos</string>
     <string name="hidden_icons_placeholder">Algumas aplicações não podem ser desinstaladas mas pode ocultar os seus ícones.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Manage hidden icons</string>
     <string name="hidden_icons">Hidden icons</string>
     <string name="hidden_icons_placeholder">Some apps cannot be uninstalled due to system restrictions, but you can at least hide their icons to avoid seeing them.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Управление скрытыми значками</string>
     <string name="hidden_icons">Скрытые значки</string>
     <string name="hidden_icons_placeholder">Некоторые приложения нельзя удалить из-за системных ограничений, но можно скрыть их значки.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -11,6 +11,9 @@
     <string name="manage_hidden_icons">Spravovať skryté ikonky</string>
     <string name="hidden_icons">Skryté ikonky</string>
     <string name="hidden_icons_placeholder">Niektoré apky nemôžu byť odinštalované kvôli systémovým obmedzeniam, viete ich ale aspoň skryť, aby ste ich nevideli.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Upravljajte s skritimi ikonami</string>
     <string name="hidden_icons">Skrite ikone</string>
     <string name="hidden_icons_placeholder">Določenih aplikacij zaradi sistemskih omejitev ni mogoče odstraniti, njihove ikone pa skrijete, da jih ne vidite.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Управљајте скривеним иконама</string>
     <string name="hidden_icons">Скривене иконе</string>
     <string name="hidden_icons_placeholder">Неке апликације се не могу деинсталирати због системских ограничења, али можете барем сакрити њихове иконе да их не видите.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Hantera dolda ikoner</string>
     <string name="hidden_icons">Dolda ikoner</string>
     <string name="hidden_icons_placeholder">Vissa appar kan inte avinstalleras på grund av systembegränsningar, men du kan åtminstone dölja deras ikoner för att slippa se dem.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Gizli simgeleri yönet</string>
     <string name="hidden_icons">Gizli simgeler</string>
     <string name="hidden_icons_placeholder">Bazı uygulamalar sistem kısıtlamaları nedeniyle kaldırılamaz, ancak en azından onları görmemek için simgelerini gizleyebilirsiniz.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">Керування прихованими піктограмами</string>
     <string name="hidden_icons">Приховані піктограми</string>
     <string name="hidden_icons_placeholder">Деякі застосунки не можна видалити через системні обмеження, але ви можете принаймні приховати їх піктограми, щоб уникнути їх перегляду.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-zgh/strings.xml
+++ b/app/src/main/res/values-zgh/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">ⴰⵙⵡⵓⴷⴷⵓ ⵏ ⵜⵙⵓⵔⴰ ⵉⴼⴼⵔⵏ</string>
     <string name="hidden_icons">ⵜⵉⵙⵓⵔⴰ ⵉⴼⴼⵔⵏ</string>
     <string name="hidden_icons_placeholder">ⵓⵔ ⵜⵣⵔⵉⵏ ⵜⵓⵙⵙⵔⴰ ⵏ ⴽⵔⴰ ⵏ ⵜⵙⵏⵙⵉⵡⵉⵏ ⵙ ⵜⵎⵏⵜⵉⵍⵜ ⵏ ⵉⵙⵍⴳⵏⵏ ⵏ ⵓⵏⴳⵔⴰⵡ, ⵎⴰⵛⴰ ⵜⵣⵔⵉ ⵜⵓⴼⴼⵔⴰ ⵏ ⵜⵙⵓⵔⴰ ⵏⵏⵙⵏⵜ ⵃⵎⴰ ⵓⵔ ⴷ ⵜⵜⴹⵀⴰⵕⵏⵜ.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,4 +11,7 @@
     <string name="manage_hidden_icons">管理隐藏的图标</string>
     <string name="hidden_icons">隐藏的图标</string>
     <string name="hidden_icons_placeholder">某些应用因系统限制而无法卸载， 但你至少可以隐藏它们的图标避免看见它们。</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="manage_hidden_icons">Manage hidden icons</string>
     <string name="hidden_icons">Hidden icons</string>
     <string name="hidden_icons_placeholder">Some apps cannot be uninstalled due to system restrictions, but you can at least hide their icons to avoid seeing them.</string>
+    <string name="set_drawer_grid_text">Set Rows &amp; Columns</string>
+    <string name="grid_text" translatable="false">%1$d X %2$d</string>
+    <string name="rows">Rows</string>
+    <string name="columns">Columns</string>
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
This PR is a feature request for https://github.com/SimpleMobileTools/Simple-Launcher/issues/60

https://github.com/SimpleMobileTools/Simple-Launcher/assets/25471892/fbfb8b16-3cd3-40f8-bf35-6d30bcd63e61

## Changes and notes
- Added an extra option in the settings screen to set the desired row and column count through a dialog
- Tested on Samsung Note 9 (Android 13), Xiaomi Realme Note 10(Android 11)

