### PR TITLE
Fix crash when removing last hidden icon from HiddenIconsActivity

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/HiddenIconsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/HiddenIconsActivity.kt
@@ -46,7 +46,11 @@ class HiddenIconsActivity : SimpleActivity(), RefreshRecyclerViewListener {
                 })
             ).toMutableList() as ArrayList<HiddenIcon>
 
-            manage_hidden_icons_placeholder.beVisibleIf(hiddenIcons.isEmpty())
+            val hiddenIconsEmpty = hiddenIcons.isEmpty()
+            runOnUiThread {
+                manage_hidden_icons_placeholder.beVisibleIf(hiddenIconsEmpty)
+            }
+
             if (hiddenIcons.isNotEmpty()) {
                 val intent = Intent(Intent.ACTION_MAIN, null)
                 intent.addCategory(Intent.CATEGORY_LAUNCHER)


### PR DESCRIPTION
This used to crash with:
    android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
            at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:8372)
            at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:1444)

This prevents that crash by ensuring that updates to `manage_hidden_icons_placeholder` happens on UI thread