### PR TITLE
Store all shortcuts with IDs without Intent

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/extensions/Activity.kt
@@ -8,7 +8,6 @@ import android.provider.Settings
 import com.simplemobiletools.commons.extensions.showErrorToast
 import com.simplemobiletools.launcher.activities.SettingsActivity
 import com.simplemobiletools.launcher.helpers.UNINSTALL_APP_REQUEST_CODE
-import com.simplemobiletools.launcher.models.HomeScreenGridItem
 
 fun Activity.launchApp(packageName: String, activityName: String) {
     // if this is true, launch the app settings
@@ -46,15 +45,5 @@ fun Activity.uninstallApp(packageName: String) {
     Intent(Intent.ACTION_DELETE).apply {
         data = Uri.fromParts("package", packageName, null)
         startActivityForResult(this, UNINSTALL_APP_REQUEST_CODE)
-    }
-}
-
-// launch static or dynamic shortcuts that have intents as string
-fun Activity.launchShortcutIntent(item: HomeScreenGridItem) {
-    try {
-        val intent = Intent.parseUri(item.intent, 0)
-        startActivity(intent)
-    } catch (e: Exception) {
-        showErrorToast(e)
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -20,6 +20,7 @@ import android.util.Size
 import android.util.SizeF
 import android.view.View
 import android.widget.RelativeLayout
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
@@ -426,12 +427,12 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) : Rel
                             storeAndShowGridItem(newHomeScreenGridItem)
                         }
                     } else if (newHomeScreenGridItem.type == ITEM_TYPE_SHORTCUT) {
-                        (context as? MainActivity)?.handleShorcutCreation(newHomeScreenGridItem.activityInfo!!) { label, icon, intent ->
+                        (context as? MainActivity)?.handleShorcutCreation(newHomeScreenGridItem.activityInfo!!) { shortcutId, label, icon ->
                             ensureBackgroundThread {
+                                newHomeScreenGridItem.shortcutId = shortcutId
                                 newHomeScreenGridItem.title = label
-                                newHomeScreenGridItem.icon = icon
-                                newHomeScreenGridItem.intent = intent
-                                newHomeScreenGridItem.drawable = BitmapDrawable(icon)
+                                newHomeScreenGridItem.icon = icon.toBitmap()
+                                newHomeScreenGridItem.drawable = icon
                                 storeAndShowGridItem(newHomeScreenGridItem)
                             }
                         }


### PR DESCRIPTION
This handles all shortcuts the same, using the recommended mechanism of using `LauncherApps` to get `PinItemRequest` from result intent. This makes `intent` field obsolete.

This closes #67