### PR TITLE
Add migration for changes made to shortcuts

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
@@ -146,7 +146,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                     ITEM_TYPE_SHORTCUT,
                     "",
                     -1,
-                    "",
                     shortcutId,
                     icon.toBitmap(),
                     false,
@@ -780,7 +779,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         "",
                         -1,
                         "",
-                        "",
                         null,
                         true
                     )
@@ -806,7 +804,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         ITEM_TYPE_ICON,
                         "",
                         -1,
-                        "",
                         "",
                         null,
                         true
@@ -836,7 +833,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         "",
                         -1,
                         "",
-                        "",
                         null,
                         true
                     )
@@ -863,7 +859,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         ITEM_TYPE_ICON,
                         "",
                         -1,
-                        "",
                         "",
                         null,
                         true
@@ -893,7 +888,6 @@ class MainActivity : SimpleActivity(), FlingListener {
                         ITEM_TYPE_ICON,
                         "",
                         -1,
-                        "",
                         "",
                         null,
                         true

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/databases/AppsDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/databases/AppsDatabase.kt
@@ -68,9 +68,11 @@ abstract class AppsDatabase : RoomDatabase() {
 
         private val MIGRATION_4_5 = object : Migration(4, 5) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE home_screen_grid_items ADD COLUMN page INTEGER NOT NULL DEFAULT 0")
-                database.execSQL("ALTER TABLE home_screen_grid_items ADD COLUMN docked INTEGER NOT NULL DEFAULT 0")
-                database.execSQL("UPDATE home_screen_grid_items SET docked = 1 WHERE page = 0 AND type != 1 AND top = 5")
+                database.execSQL("CREATE TABLE `home_screen_grid_items_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `left` INTEGER NOT NULL, `top` INTEGER NOT NULL, `right` INTEGER NOT NULL, `bottom` INTEGER NOT NULL, `page` INTEGER NOT NULL, `package_name` TEXT NOT NULL, `activity_name` TEXT NOT NULL, `title` TEXT NOT NULL, `type` INTEGER NOT NULL, `class_name` TEXT NOT NULL, `widget_id` INTEGER NOT NULL, `shortcut_id` TEXT NOT NULL, `icon` BLOB, `docked` INTEGER NOT NULL DEFAULT 0)")
+                database.execSQL("INSERT INTO `home_screen_grid_items_new` (`id`, `left`, `top`, `right`, `bottom`, `page`, `package_name`, `activity_name`, `title`, `type`, `class_name`, `widget_id`, `shortcut_id`, `icon`, `docked`)  SELECT `id`, `left`, `top`, `right`, `bottom`, 0 as `page`, `package_name`, `activity_name`, `title`, `type`, `class_name`, `widget_id`, `shortcut_id`, `icon`, CASE WHEN `type` != 1 AND `top` = 5 THEN 1 ELSE 0 END AS `docked` FROM `home_screen_grid_items` WHERE `intent` IS NULL OR `intent` = ''")
+                database.execSQL("DROP TABLE `home_screen_grid_items`")
+                database.execSQL("ALTER TABLE `home_screen_grid_items_new` RENAME TO `home_screen_grid_items`")
+                database.execSQL("CREATE UNIQUE INDEX `index_home_screen_grid_items_id` ON `home_screen_grid_items` (`id`)")
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/AllAppsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/AllAppsFragment.kt
@@ -206,7 +206,6 @@ class AllAppsFragment(context: Context, attributeSet: AttributeSet) : MyFragment
             "",
             -1,
             "",
-            "",
             null,
             false,
             appLauncher.drawable

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/WidgetsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/fragments/WidgetsFragment.kt
@@ -264,7 +264,6 @@ class WidgetsFragment(context: Context, attributeSet: AttributeSet) : MyFragment
             appWidget.className,
             -1,
             "",
-            "",
             null,
             false,
             appWidget.widgetPreviewImage,

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/models/HomeScreenGridItem.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/models/HomeScreenGridItem.kt
@@ -22,7 +22,6 @@ data class HomeScreenGridItem(
     @ColumnInfo(name = "type") var type: Int,
     @ColumnInfo(name = "class_name") var className: String,
     @ColumnInfo(name = "widget_id") var widgetId: Int,
-    @ColumnInfo(name = "intent") var intent: String,            // used at static and dynamic shortcuts on click
     @ColumnInfo(name = "shortcut_id") var shortcutId: String,   // used at pinned shortcuts at startLauncher call
     @ColumnInfo(name = "icon") var icon: Bitmap? = null,        // store images of pinned shortcuts, those cannot be retrieved after creating
     @ColumnInfo(name = "docked") var docked: Boolean = false,   // special flag, meaning that page, top and bottom don't matter for this item, it is always at the bottom of the screen
@@ -33,7 +32,7 @@ data class HomeScreenGridItem(
     @Ignore var widthCells: Int = 1,
     @Ignore var heightCells: Int = 1
 ) {
-    constructor() : this(null, -1, -1, -1, -1, 0, "", "", "", ITEM_TYPE_ICON, "", -1, "", "", null, false, null, null, null, 1, 1)
+    constructor() : this(null, -1, -1, -1, -1, 0, "", "", "", ITEM_TYPE_ICON, "", -1, "", null, false, null, null, null, 1, 1)
 
     fun getWidthInCells() = if (right == -1 || left == -1) {
         widthCells

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -414,7 +414,6 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) : Rel
                         "",
                         -1,
                         "",
-                        "",
                         draggedItem!!.icon,
                         yIndex == rowCount - 1,
                         draggedItem!!.drawable,


### PR DESCRIPTION
Since #67 was fixed in #92, `intent` field in `HomeScreenGridItem` became obsolete. This removes that field and properly migrates it, by adding this to existing version 4 to 5 migration (meaning this will only properly migrate between real releases). The migration will also remove all icons that had `intent` field populated, since they can't be migrated properly and would not work at all.