### PR TITLE
Improve page change behavior

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
@@ -749,6 +749,10 @@ class MainActivity : SimpleActivity(), FlingListener {
     }
 
     override fun onFlingUp() {
+        if (mIgnoreYMoveEvents) {
+            return
+        }
+
         if (!isWidgetsFragmentExpanded()) {
             mIgnoreUpEvent = true
             showFragment(binding.allAppsFragment)
@@ -757,6 +761,10 @@ class MainActivity : SimpleActivity(), FlingListener {
 
     @SuppressLint("WrongConstant")
     override fun onFlingDown() {
+        if (mIgnoreYMoveEvents) {
+            return
+        }
+
         mIgnoreUpEvent = true
         if (isAllAppsFragmentExpanded()) {
             hideFragment(binding.allAppsFragment)
@@ -771,11 +779,19 @@ class MainActivity : SimpleActivity(), FlingListener {
     }
 
     override fun onFlingRight() {
+        if (mIgnoreXMoveEvents) {
+            return
+        }
+
         mIgnoreUpEvent = true
         binding.homeScreenGrid.root.prevPage(redraw = true)
     }
 
     override fun onFlingLeft() {
+        if (mIgnoreXMoveEvents) {
+            return
+        }
+
         mIgnoreUpEvent = true
         binding.homeScreenGrid.root.nextPage(redraw = true)
     }

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/activities/MainActivity.kt
@@ -60,6 +60,8 @@ class MainActivity : SimpleActivity(), FlingListener {
     private var mMoveGestureThreshold = 0
     private var mIgnoreUpEvent = false
     private var mIgnoreMoveEvents = false
+    private var mIgnoreXMoveEvents = false
+    private var mIgnoreYMoveEvents = false
     private var mLongPressedIcon: HomeScreenGridItem? = null
     private var mOpenPopupMenu: PopupMenu? = null
     private var mCachedLaunchers = ArrayList<AppLauncher>()
@@ -362,13 +364,20 @@ class MainActivity : SimpleActivity(), FlingListener {
 
                 if (hasFingerMoved && !mIgnoreMoveEvents) {
                     val diffY = mTouchDownY - event.y
+                    val diffX = mTouchDownX - event.x
 
-                    if (isWidgetsFragmentExpanded()) {
-                        val newY = mWidgetsFragmentY - diffY
-                        binding.widgetsFragment.root.y = Math.min(Math.max(0f, newY), mScreenHeight.toFloat())
-                    } else if (mLongPressedIcon == null) {
-                        val newY = mAllAppsFragmentY - diffY
-                        binding.allAppsFragment.root.y = Math.min(Math.max(0f, newY), mScreenHeight.toFloat())
+                    if (abs(diffY) > abs(diffX) && !mIgnoreYMoveEvents) {
+                        mIgnoreXMoveEvents = true
+                        if (isWidgetsFragmentExpanded()) {
+                            val newY = mWidgetsFragmentY - diffY
+                            binding.widgetsFragment.root.y = Math.min(Math.max(0f, newY), mScreenHeight.toFloat())
+                        } else if (mLongPressedIcon == null) {
+                            val newY = mAllAppsFragmentY - diffY
+                            binding.allAppsFragment.root.y = Math.min(Math.max(0f, newY), mScreenHeight.toFloat())
+                        }
+                    } else if (abs(diffX) > abs(diffY) && !mIgnoreXMoveEvents) {
+                        mIgnoreYMoveEvents = true
+                        binding.homeScreenGrid.root.setSwipeMovement(diffX)
                     }
                 }
 
@@ -386,18 +395,27 @@ class MainActivity : SimpleActivity(), FlingListener {
                 binding.homeScreenGrid.root.itemDraggingStopped()
 
                 if (!mIgnoreUpEvent) {
-                    if (binding.allAppsFragment.root.y < mScreenHeight * 0.5) {
-                        showFragment(binding.allAppsFragment)
-                    } else if (isAllAppsFragmentExpanded()) {
-                        hideFragment(binding.allAppsFragment)
+                    if (!mIgnoreYMoveEvents) {
+                        if (binding.allAppsFragment.root.y < mScreenHeight * 0.5) {
+                            showFragment(binding.allAppsFragment)
+                        } else if (isAllAppsFragmentExpanded()) {
+                            hideFragment(binding.allAppsFragment)
+                        }
+
+                        if (binding.widgetsFragment.root.y < mScreenHeight * 0.5) {
+                            showFragment(binding.widgetsFragment)
+                        } else if (isWidgetsFragmentExpanded()) {
+                            hideFragment(binding.widgetsFragment)
+                        }
                     }
 
-                    if (binding.widgetsFragment.root.y < mScreenHeight * 0.5) {
-                        showFragment(binding.widgetsFragment)
-                    } else if (isWidgetsFragmentExpanded()) {
-                        hideFragment(binding.widgetsFragment)
+                    if (!mIgnoreXMoveEvents) {
+                        binding.homeScreenGrid.root.finalizeSwipe()
                     }
                 }
+
+                mIgnoreXMoveEvents = false
+                mIgnoreYMoveEvents = false
             }
         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -1176,6 +1176,7 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) : Rel
             } else {
                 currentPage + 1
             }
+            pageChangeSwipedPercentage = sign(pageChangeSwipedPercentage) * (1 - abs(pageChangeSwipedPercentage))
             handlePageChange(true)
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -973,7 +973,7 @@ class HomeScreenGrid(context: Context, attrs: AttributeSet, defStyle: Int) : Rel
 
 
     fun setSwipeMovement(diffX: Float) {
-        if (draggedItem != null) {
+        if (draggedItem == null) {
             pager.setSwipeMovement(diffX)
         }
     }


### PR DESCRIPTION
This adds ability to drag between pages and change them slowly, without having to swipe to change the page. This also fixes drawing of widgets during swipes (previously widgets suddenly appeared after swiping, instead of being visible during the whole movement).