### PR TITLE
Reduce target SDK to 33

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -21,8 +21,8 @@ import android.util.AttributeSet
 import android.util.Size
 import android.util.SizeF
 import android.view.View
-import android.view.animation.OvershootInterpolator
 import android.view.animation.DecelerateInterpolator
+import android.view.animation.OvershootInterpolator
 import android.widget.RelativeLayout
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toDrawable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ simple-commons = "c5a32fb1f3"
 gradlePlugins-agp = "8.1.0"
 #build
 app-build-compileSDKVersion = "34"
-app-build-targetSDK = "34"
+app-build-targetSDK = "33"
 app-build-minimumSDK = "26"
 app-build-javaVersion = "VERSION_17"
 app-build-kotlinJVMTarget = "17"


### PR DESCRIPTION
This is done to allow configuring widgets on SDK 34. It seems that this is not yet fully supported, since SDK 34 is in beta. System blocks starting widget configuration when target SDK 34, probably due to https://developer.android.com/about/versions/14/behavior-changes-14#background-activity-restrictions