### PR TITLE
Prevent widgets flicker by skipping the last update in animation

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/launcher/views/HomeScreenGrid.kt
@@ -1931,8 +1931,10 @@ private class AnimatedGridPager(
             .apply {
                 interpolator = OvershootInterpolator(1f)
                 addUpdateListener {
-                    pageChangeAnimLeftPercentage = it.animatedValue as Float
-                    redrawGrid()
+                    if (it.animatedValue != 0f) {
+                        pageChangeAnimLeftPercentage = it.animatedValue as Float
+                        redrawGrid()
+                    }
                 }
                 addListener(object : AnimatorListenerAdapter() {
                     override fun onAnimationEnd(animation: Animator) {


### PR DESCRIPTION
This closes #133